### PR TITLE
fix: Fixed typo in the devtools panel (messaging example)

### DIFF
--- a/messaging/panel.js
+++ b/messaging/panel.js
@@ -22,7 +22,7 @@ var pageY = document.querySelector("#pageY");
 port.onMessage.addListener(function(message) {
   console.log("panel: onMessage", message);
 
-  switch (msg.action) {
+  switch (message.action) {
     case 'mousemove':
       pageX.innerHTML = message.pageX;
       pageY.innerHTML = message.pageY;


### PR DESCRIPTION
This PR fixes a small typo in the devtools panel from the messaging example.