### PR TITLE
Fix and prevent some messaging logged errors

### DIFF
--- a/messaging/panel.js
+++ b/messaging/panel.js
@@ -41,14 +41,8 @@ function post(message) {
  * script).
  */
 clearPage.addEventListener("click", event => {
-  post({
-    action: "clearPage",
-    target: "content"
-  });
+  chrome.runtime.sendMessage({action: "clearPage", target: "content", tabId});
 }, false);
 
 // Sent initialization message.
-post({
-  action: "init",
-  tabId: tabId
-});
+post({action: "init"});


### PR DESCRIPTION
This PR contains the following tweaks to the messaging example:

- in the content script:
  - setup the port connection lazily once we have to send the first message to the background page on that port, and send the stream of mousemove events on this lazily connected port (the stream of mousemove events is a good candidate to be sent over the persisten connection provided by the connected port)[1]
  - subscribe the handler of the "clearPage" request using "runtime.onMessage" ("clearPage" is a "one-shot request" instead of a stream of messages, and so it looks like a good candidate to be sent over a single message instead of a connected port)[2] 

- in the background page:
  - fix the "connections map cleanup" when a port is disconnected
  - change the runtime.onMessage listener to route the "clearPage" messages to the tab (instead of routing the stream of mousemove messages, which are sent to the panel over the connected port)
  - minor tweaks (e.g. the second parameter of port.onMessage is the port and not the sender, and so I applied some minor tweaks to use the port object received by the runtime.onConnect listener instead of the second parameter of the port.onMessage listener)

- in the devtools panel:
  - send the "clearPage" request using the runtime.sendMessage event (mainly to use the "runtime.onMessage" listener in the background script as an example of how to route "one-shot requests" from the panel to the tab using "tabs.sendMessage")
  - minor tweaks (e.g. tabId is already set by the "post" utility function).

[1]: this change prevents the "No matching message handler for the given recipient" errors logged when the addon is installed and there are already tabs with regular webpage loaded into them (this error happens when the content script is loaded before the background page is ready to receive a connection or a message because is still loading)
[2]: this change makes the panel able to send the request to the content script even if there is no port connected from the content script to the background page yet